### PR TITLE
Allow sbox hashers to hash anything.

### DIFF
--- a/lib/sbox_hash.rkt
+++ b/lib/sbox_hash.rkt
@@ -48,3 +48,6 @@ class SboxHash:
 
 # Creates a 64-bit hash function
 def SboxHash64(): SboxHash(64)
+
+def HashFunctionC(X): FunC[X, int?]
+def make_sbox_hash(): return SboxHash64().apply

--- a/lib/sbox_hash.rkt
+++ b/lib/sbox_hash.rkt
@@ -2,7 +2,8 @@
 
 # Each instance is a randomly generated hash function. The constructor
 # takes the bit length for the resulting hash codes. The only method,
-# `apply`, hashes a string to an integer of the requested bit length.
+# `apply`, hashes the string representation of its input to an integer
+# of the requested bit length.
 class SboxHash:
     let hash_max: nat?
     let start:    nat?
@@ -28,7 +29,8 @@ class SboxHash:
         3 * hash_code 
 
     # Applies the hash function.
-    def apply(self, input_string: str?) -> nat?:
+    def apply(self, input: AnyC) -> nat?:
+        let input_string = '%d'.format(input)
         let hash_code = self.start
         for c in input_string:
             hash_code = self._mix(self._combine(hash_code, c)) & self.hash_max


### PR DESCRIPTION
As we discussed yesterday.

Also, I'm not sure I like the new object interface to sbox hashers.
They're not really hash "functions" anymore, and lose uniformity with random hash functions students may write (e.g., first_char_hasher).