### PR TITLE
array tests and clone bugfix

### DIFF
--- a/lib/array.rkt
+++ b/lib/array.rkt
@@ -78,7 +78,7 @@ class Array[T] (ITERABLE):
             self._data = [ self._data[i] for i in range(self._len) ]
 
     def clone(self) -> Array?:
-        let result = Array(T, self._len)
+        let result = Array[T](self._len)
         for i in range(self._len):
             result.push(self.get(i))
         result

--- a/test/dssl2/array.rkt
+++ b/test/dssl2/array.rkt
@@ -25,3 +25,33 @@ assert a.get(1) == 10
 assert a.get(2) == 4
 
 assert_error array()[0], 'Array index out of bounds: 0 >= 0'
+
+let x = Array(5)
+assert x.capacity() == 5
+for i in range(8):
+    x.push(i)
+
+x[0] = 100
+
+assert x[0] == 100
+assert x[1] == 1
+
+let y = x.clone()
+assert (x == y)
+
+x.push_front(99)
+assert x[0] == 99
+assert x[1] == 100
+assert x[2] == 1
+assert x.pop_front() == 99
+assert x == y
+assert x.pop_back() == 7
+x.push(7)
+assert x == y
+x.shrink_to_fit()
+assert x.capacity() == 8
+
+let c = Array[int?](5)
+assert_error c.push("string")
+let d = c.clone()
+assert_error d.push("string")


### PR DESCRIPTION
Added tests for the following methods of array: pushing over capacity, clone, equality, push_front, pop_front, pop_back, and contracts. Fixed the constructor for clone that was giving an arity mismatch error.