### PR TITLE
Fix printing of `time` case results to match documentation

### DIFF
--- a/private/printer.rkt
+++ b/private/printer.rkt
@@ -149,7 +149,20 @@
            (display #\] port))]
         [(struct-base? value)
          (unless (seen!? value)
-           (write-struct value port visit))]
+           (define info (struct-base-struct-info value))
+           (cond 
+            [(eq? (struct-info-name info) 'timing)
+                  (define (get-field-value struct sym) ((field-info-getter (get-field-info value sym)) struct))
+                  (let ([label (get-field-value value 'label)]
+                        [cpu (get-field-value value 'cpu)]
+                        [real (get-field-value value 'real)]
+                        [gc (get-field-value value 'gc)])
+                        (fprintf port "~a: cpu: ~ams real: ~ams gc: ~ams"
+                                 label
+                                 cpu
+                                 real
+                                 gc))]
+            [else (write-struct value port visit)]))]
         [(object-base? value)
          (unless (seen!? value)
            (cond

--- a/scribblings/statement-forms.scrbl
+++ b/scribblings/statement-forms.scrbl
@@ -806,7 +806,7 @@ time '10,000,000 zeroes':
 The result is printed as follows:
 
 @verbatim|{
-10,000,000 zeroes: cpu: 309 real: 792 gc: 238
+10,000,000 zeroes: cpu: 309ms real: 792ms gc: 238ms
 }|
 
 This means it tooks 309 milliseconds of CPU time over 792 milliseconds of


### PR DESCRIPTION
The results of time cases will now be printed with just timing information as [documented](https://docs.racket-lang.org/dssl2/stm-forms.html#%28form._%28%28lib._dssl2%2Fmain..rkt%29._time%29%29). 

Previously, the struct bundling the time case label, timing information, and result was printed naively. 